### PR TITLE
Added lazy classes for common CAN devices.

### DIFF
--- a/src/main/java/frc/robot/subsystems/PrimeSwerveModuleSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PrimeSwerveModuleSubsystem.java
@@ -4,7 +4,6 @@ import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.FeedbackDevice;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.TalonFXInvertType;
-import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.controller.PIDController;
@@ -15,12 +14,12 @@ import edu.wpi.first.math.kinematics.SwerveModuleState;
 import frc.robot.config.RobotMap;
 import frc.robot.prime.utilities.CTREConverter;
 import frc.robot.sensors.MA3Encoder;
+import prime.movers.LazyWPITalonFX;
 import edu.wpi.first.wpilibj2.command.PIDSubsystem;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class PrimeSwerveModuleSubsystem extends PIDSubsystem {
- private WPI_TalonFX mSteeringMotor;
- private WPI_TalonFX mDriveMotor;
+ private LazyWPITalonFX mSteeringMotor;
+ private LazyWPITalonFX mDriveMotor;
  public MA3Encoder mEncoder;
  private PIDController mSteeringPIDController;   
  private PIDController mDrivePIDController;
@@ -35,7 +34,7 @@ public class PrimeSwerveModuleSubsystem extends PIDSubsystem {
    super(new PIDController(RobotMap.kSteeringPidConstants.kP, RobotMap.kSteeringPidConstants.kI, RobotMap.kSteeringPidConstants.kD));
 
    // Set up the steering motor
-   mSteeringMotor = new WPI_TalonFX(steeringMotorId);
+   mSteeringMotor = new LazyWPITalonFX(steeringMotorId);
    mSteeringMotor.configFactoryDefault();
    mSteeringMotor.clearStickyFaults();
    mSteeringMotor.setNeutralMode(NeutralMode.Brake);
@@ -43,7 +42,7 @@ public class PrimeSwerveModuleSubsystem extends PIDSubsystem {
    mSteeringMotor.configOpenloopRamp(0.2);
 
    // Set up the drive motor
-   mDriveMotor = new WPI_TalonFX(driveMotorId);
+   mDriveMotor = new LazyWPITalonFX(driveMotorId);
    mDriveMotor.configFactoryDefault();
    mDriveMotor.clearStickyFaults();
    mDriveMotor.setNeutralMode(NeutralMode.Brake);

--- a/src/main/java/prime/movers/LazyCANSparkMax.java
+++ b/src/main/java/prime/movers/LazyCANSparkMax.java
@@ -1,0 +1,23 @@
+package prime.movers;
+
+import com.revrobotics.CANSparkMax;
+
+public class LazyCANSparkMax extends CANSparkMax {
+    protected double mLastSpeed = Double.NaN;
+
+    public LazyCANSparkMax(int deviceId, MotorType type) {
+        super(deviceId, type);
+    }
+
+    public double getLastSpeed() {
+        return mLastSpeed;
+    }
+    
+    @Override
+    public void set(double speed) {
+        if (speed == mLastSpeed) return;
+
+        mLastSpeed = speed;
+        set(speed);
+    }
+}

--- a/src/main/java/prime/movers/LazySolenoid.java
+++ b/src/main/java/prime/movers/LazySolenoid.java
@@ -1,0 +1,31 @@
+package prime.movers;
+
+import edu.wpi.first.wpilibj.PneumaticsModuleType;
+import edu.wpi.first.wpilibj.Solenoid;
+
+public class LazySolenoid extends Solenoid {
+    protected boolean mLastValue = false;
+
+    public LazySolenoid(PneumaticsModuleType moduleType, int channel) {
+        super(moduleType, channel);
+        set(false);
+    }
+
+    public LazySolenoid(int module, PneumaticsModuleType moduleType, int channel) {
+        super(module, moduleType, channel);
+        set(false);
+    }
+    
+    public Boolean getLastValue() {
+        return mLastValue;
+    }
+
+    @Override
+    public void set(boolean on) {
+        if (on == mLastValue) return;
+     
+        mLastValue = on;
+        set(on);
+    }
+
+}

--- a/src/main/java/prime/movers/LazyWPITalonFX.java
+++ b/src/main/java/prime/movers/LazyWPITalonFX.java
@@ -1,0 +1,34 @@
+package prime.movers;
+
+import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
+
+public class LazyWPITalonFX extends WPI_TalonFX {
+    protected double mLastValue = Double.NaN;
+    protected ControlMode mLastControlMode = null;
+
+    public LazyWPITalonFX(int deviceNumber) {
+        super(deviceNumber);
+    }
+
+    public LazyWPITalonFX(int deviceNumber, String name) {
+        super(deviceNumber, name);
+    }
+
+    public double getLastValue() {
+        return mLastValue;
+    }
+
+    public ControlMode getLastControlMode() {
+        return mLastControlMode;
+    }
+    
+    @Override
+    public void set(ControlMode mode, double value) {
+        if (value == mLastValue && mode == mLastControlMode) return;
+
+        mLastValue = value;
+        mLastControlMode = mode;
+        super.set(mode, value);
+    }
+}

--- a/src/main/java/prime/movers/LazyWPITalonSRX.java
+++ b/src/main/java/prime/movers/LazyWPITalonSRX.java
@@ -1,0 +1,30 @@
+package prime.movers;
+
+import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+
+public class LazyWPITalonSRX extends WPI_TalonSRX {
+    protected double mLastValue = Double.NaN;
+    protected ControlMode mLastControlMode = null;
+
+    public LazyWPITalonSRX(int deviceNumber) {
+        super(deviceNumber);
+    }
+
+    public double getLastValue() {
+        return mLastValue;
+    }
+
+    public ControlMode getLastControlMode() {
+        return mLastControlMode;
+    }
+    
+    @Override
+    public void set(ControlMode mode, double value) {
+        if (value == mLastValue && mode == mLastControlMode) return;
+        
+        mLastValue = value;
+        mLastControlMode = mode;
+        super.set(mode, value);
+    }
+}

--- a/vendordeps/REVLib.json
+++ b/vendordeps/REVLib.json
@@ -1,0 +1,73 @@
+{
+    "fileName": "REVLib.json",
+    "name": "REVLib",
+    "version": "2023.1.3",
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "mavenUrls": [
+        "https://maven.revrobotics.com/"
+    ],
+    "jsonUrl": "https://software-metadata.revrobotics.com/REVLib-2023.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-java",
+            "version": "2023.1.3"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-driver",
+            "version": "2023.1.3",
+            "skipInvalidPlatforms": true,
+            "isJar": false,
+            "validPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-cpp",
+            "version": "2023.1.3",
+            "libName": "REVLib",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        },
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-driver",
+            "version": "2023.1.3",
+            "libName": "REVLibDriver",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Added the following "lazy" CAN device classes, which wrap the original motor type and override its `set()` function so that the underlying motor is only updated when control input changes, sacrificing a few bytes for faster CAN speeds. 